### PR TITLE
Timer stop needed?

### DIFF
--- a/handler/connection.lua
+++ b/handler/connection.lua
@@ -71,7 +71,12 @@ end
 
 local function sock_close(self)
 	local sock = self.sock
-	if not sock then return end
+	if not sock then 
+	    if self.write_timer then
+		self.write_timer:stop(self.loop)
+	    end
+	    return 
+	end
 	self.is_closing = true
 	self.read_blocked = true
 	if not self.write_buf or self.has_error then


### PR DESCRIPTION
If the write_timeout kills the connection the timer seems to be still active and is running endless.
Should it be stopped here?
