### PR TITLE
problem with keepalive-closing socket

### DIFF
--- a/handler/connection.lua
+++ b/handler/connection.lua
@@ -287,7 +287,7 @@ local function sock_recv_data(self)
 			sock_handle_error(self, err)
 			return false, err
 		end
-	until len >= read_max or self.read_blocked
+	until len >= read_max or self.read_blocked or self.shutdown_waiting
 
 	return true
 end

--- a/handler/connection/tls_backend.lua
+++ b/handler/connection/tls_backend.lua
@@ -275,7 +275,7 @@ local function sock_recv_data(self)
 			sock_handle_error(self, err)
 			return false, err
 		end
-	until len >= read_max and not self.read_blocked
+	until len >= read_max and not self.read_blocked or self.shutdown_waiting
 
 	return true
 end

--- a/handler/http/server/hconnection.lua
+++ b/handler/http/server/hconnection.lua
@@ -478,6 +478,7 @@ local function create_request_parser(self)
 		if self.need_close then
 			local sock = self.sock
 			if sock then
+				self.sock.shutdown_waiting=true
 				self.sock:shutdown(true, false) -- shutdown reads, but not writes.
 			end
 			error(abort_http_parse, 0) -- end http parsing, drop all other queued http events.


### PR DESCRIPTION
I had some really curious problem on two clients using a lua-handlers server.
Every 25 http request when ~38kb data had to be delivered to the client, the client had a socket error: connection unexpectedly closed.

I first tracked it down to hconnection.lua/send_body() ~ line 355 where the sock:send(chunk) call is done.
Instead of err=="blocked" i got err=="closed" on these two clients.

Later trying to fix it i found that due to the entry in hconnection.lua/on_headers_complete ~line 430

max_requests <= 0 then self.need_close = true 
line 

the socket will be self.sock:shutdown in hconnection.lua/on_message_complete~line 481.

Now the main problem happens at connection.lua/sock_recv_data(self) ~ 255.
The socket is :shutdown() half the way and sock:recv is called in the repeat.
The next evaluation of err will tell that the socket has shut down and an error is handled instead of just sending the next data and then close the socket.

I tried to create a patch here in the branch checking for self.shutdown_waiting (which is now set on the self.sock:shutdown(...) line.

It works now but i am not sure if this is the best solution for the problem.

It is really really hard to reproduce the problem but it exists.
